### PR TITLE
Add base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ npm start
 
 Finally, load http://localhost:2999 in your web browser.
 
+You can also serve the application on a base path using the BASE_PATH environment variable.
+
+For example:
+
+```bash
+BASE_PATH=/cardgames/ npm start
+```
+
+will make the application available on http://localhost:2999/cardgames/
+
+
 How to Add a Card Set
 ---------------------
 

--- a/src/client/CovidClientEngine.js
+++ b/src/client/CovidClientEngine.js
@@ -13,7 +13,7 @@ import { ClientEngine, KeyboardControls } from 'lance-gg';
 export default class CovidClientEngine extends ClientEngine {
 
   constructor(gameEngine, options) {
-    super(gameEngine, options, CovidRenderer);
+    super(gameEngine, {...options, serverURL: window.location.origin}, CovidRenderer);
     this.selection = new Selection();
     this.privateAreaId = null;
     this.side = PrivateArea.SIDE.SOUTH;
@@ -29,6 +29,10 @@ export default class CovidClientEngine extends ClientEngine {
     gameEngine.on('gameboard_updated', this.updateHtmlDisplay.bind(this));
     gameEngine.on('updating_gameboard', this.loadingHtmlDisplay.bind(this));
     gameEngine.on('table_updated', this.onTableUpdated.bind(this));
+  }
+
+  connect(options = {}) {
+    return super.connect({...options, path: window.location.pathname + "socket.io"})
   }
 
   start() {

--- a/src/main.js
+++ b/src/main.js
@@ -5,15 +5,23 @@ import { Lib } from 'lance-gg';
 import CovidGameEngine from './common/CovidGameEngine';
 import CovidServerEngine from './server/CovidServerEngine';
 
+let BASE_PATH = process.env.BASE_PATH || "/";
+if (BASE_PATH[0] !== "/") {
+    BASE_PATH = "/" + BASE_PATH;
+}
+if (BASE_PATH[BASE_PATH.length - 1] !== "/") {
+    BASE_PATH = BASE_PATH + "/";
+}
+
 const PORT = process.env.PORT || 2999;
 const INDEX = path.join(__dirname, '../dist/index.html');
 
 // define routes and socket
 const server = express();
-server.get('/', function(req, res) { res.sendFile(INDEX); });
-server.use('/', express.static(path.join(__dirname, '../dist/')));
+server.get(BASE_PATH, function(req, res) { res.sendFile(INDEX); });
+server.use(BASE_PATH, express.static(path.join(__dirname, '../dist/')));
 let requestHandler = server.listen(PORT, () => console.log(`Listening on ${ PORT }`));
-const io = socketIO(requestHandler);
+const io = socketIO(requestHandler, {path: `${BASE_PATH}socket.io`});
 
 // Game Instances
 const gameEngine = new CovidGameEngine({ traceLevel: Lib.Trace.TRACE_NONE });


### PR DESCRIPTION
I managed to serve the application under a base path. by configuring the root of the express server and of the socket.io handler. :)
Client side, the code infer the base_path from the page url. This is not very robust but should work as long as the html is served on the base path.
Closes #4.